### PR TITLE
Support multiple rules on the same line separated by a comma

### DIFF
--- a/src/scoped.component.js
+++ b/src/scoped.component.js
@@ -79,15 +79,26 @@ export class Scoped extends React.Component {
       // The css to append to the dom
       const kremlingSelector = `[${kremlingAttrName}="${kremlingAttrValue}"]`;
       const transformedCSS = props.css.replace(/& (.+){/g, (match, cssRule) => {
-        cssRule = cssRule.trim();
-        let builtIn = false;
-          if ( ! (/^([.#]\w+)/).test(cssRule)) {
-           builtIn = true;
-          }
-          // if it's not a built-in selector, prepend the data attribute. Otherwise, append
-          return ! builtIn
-            ? `${kremlingSelector} ${cssRule}, ${kremlingSelector}${cssRule} {`
-            : `${kremlingSelector} ${cssRule}, ${cssRule}${kremlingSelector} {`;
+        return match
+          .split(",") // multiple rules on the same line split by a comma
+          .map(cssSplit => {
+            cssSplit = cssSplit.trim();
+
+            // ignore css rules that don't begin with '&'
+            if (cssSplit.indexOf('&') === -1) return cssSplit.replace('{', '').trim();
+
+            cssSplit = (/[^&](.+)[^{]+/g).exec(cssSplit)[0].trim();
+
+            let builtIn = false;
+            if (!/^([.#]\w+)/.test(cssSplit)) {
+              builtIn = true;
+            }
+            // if it's not a built-in selector, prepend the data attribute. Otherwise, append
+            return !builtIn
+              ? `${kremlingSelector} ${cssSplit}, ${kremlingSelector}${cssSplit}`
+              : `${kremlingSelector} ${cssSplit}, ${cssSplit}${kremlingSelector}`;
+          })
+          .join(", ") + ' {';
       });
 
       // The dom element

--- a/src/scoped.component.test.js
+++ b/src/scoped.component.test.js
@@ -61,7 +61,7 @@ describe("<Scoped />", function() {
     ReactDOM.unmountComponentAtNode(el);
   });
 
-  it("should create local CSS for combined CSS statements", function() {
+  it("should create local CSS for combined CSS statements & with regular", function() {
     const css = `
       & .someRule, .wow {
         background-color: red;
@@ -90,7 +90,7 @@ describe("<Scoped />", function() {
     ReactDOM.unmountComponentAtNode(el);
   });
 
-  it("should create local CSS for combined CSS statements", function() {
+  it("should create local CSS for combined CSS statements regular with &", function() {
     const css = `
       .wow, & .someRule {
         background-color: red;

--- a/src/scoped.component.test.js
+++ b/src/scoped.component.test.js
@@ -61,6 +61,93 @@ describe("<Scoped />", function() {
     ReactDOM.unmountComponentAtNode(el);
   });
 
+  it("should create local CSS for combined CSS statements", function() {
+    const css = `
+      & .someRule, .wow {
+        background-color: red;
+      }
+    `;
+
+    const el = document.createElement("div");
+
+    ReactDOM.render(
+      <div>
+        <Scoped css={css}>
+          <div>Hello</div>
+        </Scoped>
+      </div>,
+      el
+    );
+
+    expect(document.querySelectorAll(`style[type="text/css"]`)[0].innerHTML.trim()).toBe(
+      `
+      [data-kremling="0"] .someRule, [data-kremling="0"].someRule, .wow {
+        background-color: red;
+      }
+    `.trim()
+    );
+
+    ReactDOM.unmountComponentAtNode(el);
+  });
+
+  it("should create local CSS for combined CSS statements", function() {
+    const css = `
+      .wow, & .someRule {
+        background-color: red;
+      }
+    `;
+
+    const el = document.createElement("div");
+
+    ReactDOM.render(
+      <div>
+        <Scoped css={css}>
+          <div>Hello</div>
+        </Scoped>
+      </div>,
+      el
+    );
+
+    expect(document.querySelectorAll(`style[type="text/css"]`)[0].innerHTML.trim()).toBe(
+      `
+      .wow, [data-kremling="0"] .someRule, [data-kremling="0"].someRule {
+        background-color: red;
+      }
+    `.trim()
+    );
+
+    ReactDOM.unmountComponentAtNode(el);
+  });
+
+  it("should create local CSS for combined CSS statements", function() {
+    const css = `
+      & .wow, & .someRule {
+        background-color: red;
+      }
+    `;
+
+    const el = document.createElement("div");
+
+    ReactDOM.render(
+      <div>
+        <Scoped css={css}>
+          <div>Hello</div>
+        </Scoped>
+      </div>,
+      el
+    );
+
+    expect(document.querySelectorAll(`style[type="text/css"]`)[0].innerHTML.trim()).toBe(
+      `
+      [data-kremling="0"] .wow, [data-kremling="0"].wow, [data-kremling="0"] .someRule, [data-kremling="0"].someRule {
+        background-color: red;
+      }
+    `.trim()
+    );
+
+    ReactDOM.unmountComponentAtNode(el);
+  });
+
   it("should dynamically create a style local CSS for non class/id selector", function() {
     const css = `
       & div {
@@ -205,4 +292,5 @@ describe("<Scoped />", function() {
 
     ReactDOM.unmountComponentAtNode(el);
   });
+
 });


### PR DESCRIPTION
For example, all of these rules should work:

```css

& .rule, & .other {
 ...
}

.rule, & .other {
 ...
}

& .rule, .other {
 ...
}

```