### PR TITLE
Add Kremling type definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,30 @@
+import * as React from "react";
+
+export as namespace Kremling;
+export = Kremling;
+
+declare namespace Kremling {
+
+  export function css(args: any): void;
+
+  export function always(args: any): chainify;
+  export function a(args: any): chainify;
+
+  export function maybe(className: string, enabled: boolean): chainify;
+  export function m(className: string, enabled: boolean): chainify;
+
+  export function toggle(className1: string, className2: string, enabled: boolean): chainify;
+  export function t(className1: string, className2: string, enabled: boolean): chainify;
+
+  declare namespace Scoped {
+    interface Props {
+      css: string;
+      namespace?: string;
+    }
+  }
+
+  declare function chainify(previousString: string, newString: string): string;
+
+  export class Scoped extends React.Component<Kremling.Scoped.Props> {}
+
+}


### PR DESCRIPTION
I was wanting to brush up on TypeScript and figured Kremling could use some type definitions. 

These types are found automatically by TS so no need to reference them in package.json. 

VS Code is able to find these types in order to offer better IntellSense info.

![screen shot 2018-06-12 at 3 25 01 pm](https://user-images.githubusercontent.com/4202993/41320024-3834ee6e-6e5b-11e8-85d3-ae951f364ae1.png)

![screen shot 2018-06-12 at 3 54 19 pm](https://user-images.githubusercontent.com/4202993/41320029-408b7344-6e5b-11e8-8a93-606fb0f42fd9.png)
