### PR TITLE
added new prop to Scoped component "postcss"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,6 @@ typings/
 .env
 
 lib
+
+# ide things
+.idea

--- a/src/scoped.component.js
+++ b/src/scoped.component.js
@@ -160,24 +160,17 @@ export class Scoped extends React.Component {
   newPostcssState = (props) => {
     const kremlingAttrName = props.postcss.namespace || 'data-kremling';
     const kremlingAttrValue = props.postcss.id;
-    let styleRef;
-    if (this.state.styleRef && this.state.styleRef.counter) {
-      styleRef = this.state.styleRef;
-    } else {
-      styleRef = document.head.querySelector(`[${kremlingAttrName}="${kremlingAttrValue}"]`);
-    }
+    let styleRef = this.state.styleRef || document.head.querySelector(`[${kremlingAttrName}="${kremlingAttrValue}"]`);
     if (!styleRef) {
-      const style = document.createElement('style');
-      style.setAttribute(kremlingAttrName, kremlingAttrValue);
-      style.setAttribute('type', 'text/css');
-      style.innerHTML = props.postcss.styles;
-      style.counter = 1;
-      document.head.appendChild(style);
-      styleRef = style;
+      styleRef = document.createElement('style');
+      styleRef.setAttribute('type', 'text/css');
+      styleRef.counter = 1;
+    } else {
+      styleRef.counter += 1;
     }
-    else {
-      styleRef.counter = styleRef.counter + 1;
-    }
+    styleRef.setAttribute(kremlingAttrName, kremlingAttrValue);
+    styleRef.innerHTML = props.postcss.styles;
+    document.head.appendChild(styleRef);
     return {
       kremlingAttrName,
       kremlingAttrValue,

--- a/src/scoped.component.js
+++ b/src/scoped.component.js
@@ -33,7 +33,7 @@ export class Scoped extends React.Component {
     const kremlingChildren = React.Children.map(this.props.children, child => {
       if (React.isValidElement(child)) {
         return React.cloneElement(child, {[this.state.kremlingAttrName]: this.state.kremlingAttrValue});
-        } else {
+      } else {
         return child;
       }
     });

--- a/src/scoped.component.js
+++ b/src/scoped.component.js
@@ -18,6 +18,7 @@ export class Scoped extends React.Component {
 
   constructor(props) {
     super(props);
+    this.state = {};
     if (!props.css && !props.postcss) throw Error(`Kremling's <Scoped /> component requires either the 'css' or 'postcss' props.`);
     if (props.css && props.postcss) throw Error(`Kremling's <Scoped /> component requires either the 'css' or 'postcss' props. Cannot use both.`);
     if (props.postcss && !(props.postcss.styles && props.postcss.id)) throw Error(`Kremlings's <Scoped /> component 'postcss' prop requires an object containing 'styles' and 'id' properties. Try using the kremling-loader.`);
@@ -61,7 +62,7 @@ export class Scoped extends React.Component {
       if (prevProps.postcss.id !== this.props.postcss.id
         || prevProps.postcss.styles !== this.props.postcss.styles
         || prevProps.postcss.namespace !== this.props.postcss.namespace) {
-        this.doneWithPostss();
+        this.doneWithPostcss();
         this.setState(this.newPostcssState(this.props));
       }
     }
@@ -71,7 +72,7 @@ export class Scoped extends React.Component {
     if (this.props.css) {
       this.doneWithCss();
     } else {
-      this.doneWithPostss();
+      this.doneWithPostcss();
     }
   }
 
@@ -149,7 +150,7 @@ export class Scoped extends React.Component {
     }
   }
 
-  doneWithPostss = () => {
+  doneWithPostcss = () => {
     this.state.styleRef.counter -= 1;
     if (this.state.styleRef.counter === 0) {
       this.state.styleRef.parentNode.removeChild(this.state.styleRef);
@@ -159,7 +160,12 @@ export class Scoped extends React.Component {
   newPostcssState = (props) => {
     const kremlingAttrName = props.postcss.namespace || 'data-kremling';
     const kremlingAttrValue = props.postcss.id;
-    let styleRef = document.head.querySelector(`[${kremlingAttrName}="${kremlingAttrValue}"]`);
+    let styleRef;
+    if (this.state.styleRef && this.state.styleRef.counter) {
+      styleRef = this.state.styleRef;
+    } else {
+      styleRef = document.head.querySelector(`[${kremlingAttrName}="${kremlingAttrValue}"]`);
+    }
     if (!styleRef) {
       const style = document.createElement('style');
       style.setAttribute(kremlingAttrName, kremlingAttrValue);

--- a/src/scoped.postcss.test.js
+++ b/src/scoped.postcss.test.js
@@ -24,8 +24,8 @@ describe('<Scoped postcss />', function() {
     ReactDOM.unmountComponentAtNode(el);
     expect(document.head.querySelectorAll(`style[type="text/css"]`).length).toBe(0);
   });
-
-
+  
+  
   it('should create a <style> tag with postcss styles', function() {
     const css = {
       id: 1,
@@ -61,23 +61,23 @@ describe('<Scoped postcss />', function() {
   it('when the user updates its id, component should update <style> data-kremling attribute', function() {
     let css = { id: '1', styles: `[data-kremling-1] .someRule, [data-kremling-1].someRule {background-color: red;}` };
     const component = (style) => <div><Scoped postcss={style}><div>Hello</div></Scoped></div>;
-
+  
     const el = document.createElement('div');
     ReactDOM.render(component(css), el);
     expect(document.head.querySelector('style').getAttribute('data-kremling')).toBe('1');
-
+  
     // update css
     css = { id: 'custom-id', styles: `[data-kremling-1] .someRule, [data-kremling-1].someRule {background-color: red;}` };
     ReactDOM.render(component(css), el);
     expect(document.head.querySelector('style').getAttribute('data-kremling')).toBe('custom-id');
   });
-
+  
   it('should increment/decrement <style> counter when there\'s multiples of the same component', function() {
     const css = { id: '1', styles: `[data-kremling="1"] .someRule, [data-kremling="1"].someRule {background-color: red;}` };
-
+  
     const el1 = document.createElement('div');
     const el2 = document.createElement('div');
-
+  
     ReactDOM.render(
       <div>
         <Scoped postcss={css}>
@@ -87,7 +87,7 @@ describe('<Scoped postcss />', function() {
       el1
     );
     expect(document.head.querySelector('style').counter).toBe(1);
-
+  
     ReactDOM.render(
       <div>
         <Scoped postcss={css}>

--- a/src/scoped.postcss.test.js
+++ b/src/scoped.postcss.test.js
@@ -1,0 +1,98 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import { Scoped } from "./scoped.component.js";
+
+function getSelectorFromId(id) {
+  return `style_${id.slice(1)}`
+}
+
+describe('<Scoped postcss />', function() {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  })
+
+
+  it("should generate and cleanup style tags", function() {
+    expect(document.head.querySelectorAll(`style[type="text/css"]`).length).toBe(0);
+    const css = {
+      id: '.kremling_id_1',
+      styles: `.kremling_id_1 .someRule, .kremling_id_1.someRule {background-color: red;}`,
+    }
+    const el = document.createElement('div');
+    ReactDOM.render(
+      <Scoped postcss={css}>
+        <div className="crazy">Okay</div>
+      </Scoped>,
+      el
+    );
+    expect(document.head.querySelectorAll(`style[type="text/css"]`).length).toBe(1);
+    ReactDOM.unmountComponentAtNode(el);
+    expect(document.head.querySelectorAll(`style[type="text/css"]`).length).toBe(0);
+  });
+
+
+  it('should create a <style> tag with postcss styles', function() {
+    const css = {
+      id: '.kremling_id_1',
+      styles: `.kremling_id_1 .someRule, .kremling_id_1.someRule {background-color: red;}`,
+    }
+    const el = document.createElement('div');
+    ReactDOM.render(
+      <div>
+        <Scoped postcss={css}>
+          <div>Hello</div>
+        </Scoped>
+      </div>,
+      el
+    );
+    expect(document.head.querySelector(`.${getSelectorFromId(css.id)}`).innerHTML).toBe(css.styles);
+  });
+
+
+  it('should update <style> tag className and styles on change', function() {
+    let css = { id: '.kremling_id_1', styles: `.kremling_id_1 .someRule, .kremling_id_1.someRule {background-color: red;}` };
+    const component = (style) => <div><Scoped postcss={style}><div>Hello</div></Scoped></div>;
+
+    const el = document.createElement('div');
+    ReactDOM.render(component(css), el);
+    expect(document.head.querySelector('style').classList.contains(getSelectorFromId(css.id))).toBe(true);
+
+    // update css
+    css = { id: '.kremling_id_2', styles: `.kremling_id_2 .someRule, .kremling_id_2.someRule {background-color: green;}` };
+    ReactDOM.render(component(css), el);
+    expect(document.head.querySelector('style').classList.contains(getSelectorFromId(css.id))).toBe(true);
+  });
+
+
+  it('should increment/decrement <style> counter when there\'s multiples of the same component', function() {
+    const css = { id: '.kremling_id_1', styles: `.kremling_id_1 .someRule, .kremling_id_1.someRule {background-color: red;}` };
+
+    const el1 = document.createElement('div');
+    const el2 = document.createElement('div');
+
+    ReactDOM.render(
+      <div>
+        <Scoped postcss={css}>
+          <div>Hello</div>
+        </Scoped>
+      </div>,
+      el1
+    );
+    expect(document.head.querySelector('style').counter).toBe(1);
+
+    ReactDOM.render(
+      <div>
+        <Scoped postcss={css}>
+          <div>Hello</div>
+        </Scoped>
+      </div>,
+      el2
+    );
+    expect(document.head.querySelector('style').counter).toBe(2);
+    ReactDOM.unmountComponentAtNode(el1);
+    expect(document.head.querySelector('style').counter).toBe(1);
+    ReactDOM.unmountComponentAtNode(el2);
+    expect(document.head.querySelector('style')).toBe(null);
+  });
+});

--- a/src/scoped.postcss.test.js
+++ b/src/scoped.postcss.test.js
@@ -1,23 +1,17 @@
 import React from "react";
 import ReactDOM from "react-dom";
-
 import { Scoped } from "./scoped.component.js";
-
-function getSelectorFromId(id) {
-  return `style_${id.slice(1)}`
-}
 
 describe('<Scoped postcss />', function() {
   beforeEach(() => {
     document.head.innerHTML = '';
-  })
-
+  });
 
   it("should generate and cleanup style tags", function() {
     expect(document.head.querySelectorAll(`style[type="text/css"]`).length).toBe(0);
     const css = {
-      id: '.kremling_id_1',
-      styles: `.kremling_id_1 .someRule, .kremling_id_1.someRule {background-color: red;}`,
+      id: 1,
+      styles: `[data-kremling="1"] .someRule, [data-kremling="1"].someRule {background-color: red;}`,
     }
     const el = document.createElement('div');
     ReactDOM.render(
@@ -34,8 +28,8 @@ describe('<Scoped postcss />', function() {
 
   it('should create a <style> tag with postcss styles', function() {
     const css = {
-      id: '.kremling_id_1',
-      styles: `.kremling_id_1 .someRule, .kremling_id_1.someRule {background-color: red;}`,
+      id: 1,
+      styles: `[data-kremling="1"] .someRule, [data-kremling="1"].someRule {background-color: red;}`,
     }
     const el = document.createElement('div');
     ReactDOM.render(
@@ -46,27 +40,40 @@ describe('<Scoped postcss />', function() {
       </div>,
       el
     );
-    expect(document.head.querySelector(`.${getSelectorFromId(css.id)}`).innerHTML).toBe(css.styles);
+    expect(document.head.querySelector(`[data-kremling="${css.id}"]`).innerHTML).toBe(css.styles);
   });
 
 
-  it('should update <style> tag className and styles on change', function() {
-    let css = { id: '.kremling_id_1', styles: `.kremling_id_1 .someRule, .kremling_id_1.someRule {background-color: red;}` };
+  it('when webpack updates its styles, component should update the data-kremling attribute and inner css', function() {
+    let css = { id: '1', styles: `[data-kremling-1] .someRule, [data-kremling-1].someRule {background-color: red;}` };
     const component = (style) => <div><Scoped postcss={style}><div>Hello</div></Scoped></div>;
 
     const el = document.createElement('div');
     ReactDOM.render(component(css), el);
-    expect(document.head.querySelector('style').classList.contains(getSelectorFromId(css.id))).toBe(true);
+    expect(document.head.querySelector('style').getAttribute('data-kremling')).toBe('1');
 
     // update css
-    css = { id: '.kremling_id_2', styles: `.kremling_id_2 .someRule, .kremling_id_2.someRule {background-color: green;}` };
+    css = { id: '2', styles: `[data-kremling-2] .someRule, [data-kremling-2].someRule {background-color: green;}` };
     ReactDOM.render(component(css), el);
-    expect(document.head.querySelector('style').classList.contains(getSelectorFromId(css.id))).toBe(true);
+    expect(document.head.querySelector('style').getAttribute('data-kremling')).toBe('2');
   });
 
+  it('when the user updates its id, component should update <style> data-kremling attribute', function() {
+    let css = { id: '1', styles: `[data-kremling-1] .someRule, [data-kremling-1].someRule {background-color: red;}` };
+    const component = (style) => <div><Scoped postcss={style}><div>Hello</div></Scoped></div>;
+
+    const el = document.createElement('div');
+    ReactDOM.render(component(css), el);
+    expect(document.head.querySelector('style').getAttribute('data-kremling')).toBe('1');
+
+    // update css
+    css = { id: 'custom-id', styles: `[data-kremling-1] .someRule, [data-kremling-1].someRule {background-color: red;}` };
+    ReactDOM.render(component(css), el);
+    expect(document.head.querySelector('style').getAttribute('data-kremling')).toBe('custom-id');
+  });
 
   it('should increment/decrement <style> counter when there\'s multiples of the same component', function() {
-    const css = { id: '.kremling_id_1', styles: `.kremling_id_1 .someRule, .kremling_id_1.someRule {background-color: red;}` };
+    const css = { id: '1', styles: `[data-kremling="1"] .someRule, [data-kremling="1"].someRule {background-color: red;}` };
 
     const el1 = document.createElement('div');
     const el2 = document.createElement('div');


### PR DESCRIPTION
Scoped component:
- new `postcss` prop to use instead of `css`
- uses classes instead of attributes
- each component tracks an `id` instead of the entire css string
- the counter is added as a property on the `<style>` tags