### PR TITLE
allow empty postcss styles

### DIFF
--- a/src/scoped.component.js
+++ b/src/scoped.component.js
@@ -21,7 +21,7 @@ export class Scoped extends React.Component {
     this.state = {};
     if (!props.css && !props.postcss) throw Error(`Kremling's <Scoped /> component requires either the 'css' or 'postcss' props.`);
     if (props.css && props.postcss) throw Error(`Kremling's <Scoped /> component requires either the 'css' or 'postcss' props. Cannot use both.`);
-    if (props.postcss && !(props.postcss.styles && props.postcss.id)) throw Error(`Kremlings's <Scoped /> component 'postcss' prop requires an object containing 'styles' and 'id' properties. Try using the kremling-loader.`);
+    if (props.postcss && !(typeof props.postcss.styles === 'string' && props.postcss.id)) throw Error(`Kremlings's <Scoped /> component 'postcss' prop requires an object containing 'styles' and 'id' properties. Try using the kremling-loader.`);
     if (props.css) {
       this.state = this.newCssState(props);
     } else {

--- a/src/scoped.postcss.test.js
+++ b/src/scoped.postcss.test.js
@@ -102,4 +102,12 @@ describe('<Scoped postcss />', function() {
     ReactDOM.unmountComponentAtNode(el2);
     expect(document.head.querySelector('style')).toBe(null);
   });
+
+  it(`shouldn't throw errors when empty postcss.styles is passed in`, () => {
+    const css = { id: '1', styles: '' };
+    const component = (style) => <div><Scoped postcss={style}><div>Hello</div></Scoped></div>;
+    const el = document.createElement('div');
+    ReactDOM.render(component(css), el);
+    expect(document.head.querySelector('style').innerHTML).toEqual('');
+  })
 });


### PR DESCRIPTION
- instead of checking for content, just make sure the `postcss.styles` property is a string. This allows you to create an empty css file and pass it into the component without it blowing up.
- `postcss.id` is still required - `kremling-loader` builds this automatically