### PR TITLE
Fixes #14 - allows Kremling to accept React Fragments as children

### DIFF
--- a/src/scoped.component.js
+++ b/src/scoped.component.js
@@ -29,14 +29,21 @@ export class Scoped extends React.Component {
     }
   }
 
-  render() {
-    const kremlingChildren = React.Children.map(this.props.children, child => {
-      if (React.isValidElement(child)) {
+  addKremlingAttributeToChildren = (children) => {
+    return React.Children.map(children, child => {
+      if (child.type === React.Fragment && React.Fragment) {
+        const fragmentChildren = this.addKremlingAttributeToChildren(child.props.children);
+        return React.cloneElement(child, {}, fragmentChildren);
+      } else if (React.isValidElement(child)) {
         return React.cloneElement(child, {[this.state.kremlingAttrName]: this.state.kremlingAttrValue});
       } else {
         return child;
       }
     });
+  }
+
+  render() {
+    const kremlingChildren = this.addKremlingAttributeToChildren(this.props.children);
 
     if (reactSupportsReturningArrays) {
       return kremlingChildren;

--- a/src/scoped.component.test.js
+++ b/src/scoped.component.test.js
@@ -362,4 +362,98 @@ describe("<Scoped />", function() {
     ReactDOM.unmountComponentAtNode(el);
   });
 
+  it("adds Kremling attribute to React Fragment children", function() {
+    const css = `
+      & .someRule {
+        background-color: red;
+      }
+    `;
+
+    const el = document.createElement("div");
+
+    ReactDOM.render(
+      <div>
+        <Scoped css={css} namespace="kackle">
+          <React.Fragment>
+            <div id="greeting">Hello</div>
+            <div id="farewell">Bye</div>
+          </React.Fragment>
+        </Scoped>
+      </div>,
+      el
+    );
+
+    expect(el.querySelector("#greeting").dataset.kackle).not.toBe(undefined);
+    expect(el.querySelector("#farewell").dataset.kackle).not.toBe(undefined);
+
+
+    ReactDOM.unmountComponentAtNode(el);
+  });
+
+  it("adds Kremling attribute to nested React Fragment children", function() {
+    const css = `
+      & .someRule {
+        background-color: red;
+      }
+    `;
+
+    const el = document.createElement("div");
+
+    ReactDOM.render(
+      <div>
+        <Scoped css={css} namespace="kackle">
+          <React.Fragment>
+            <React.Fragment>
+              <React.Fragment>
+                <div id="greeting">Hello</div>
+                <div id="farewell">Bye</div>
+              </React.Fragment>
+            </React.Fragment>
+          </React.Fragment>
+        </Scoped>
+      </div>,
+      el
+    );
+
+    expect(el.querySelector("#greeting").dataset.kackle).not.toBe(undefined);
+    expect(el.querySelector("#farewell").dataset.kackle).not.toBe(undefined);
+
+
+    ReactDOM.unmountComponentAtNode(el);
+  });
+
+  it("adds Kremling attribute to mixture of React Fragment and DOM Element children", function() {
+    const css = `
+      & .someRule {
+        background-color: red;
+      }
+    `;
+
+    const el = document.createElement("div");
+
+    ReactDOM.render(
+      <div>
+        <Scoped css={css} namespace="kackle">
+          <React.Fragment>
+            <div id="greeting">Hello</div>
+            <div id="farewell">Bye</div>
+          </React.Fragment>
+          <div id="color">Blue</div>
+          <React.Fragment>
+            <div id="color2">Green</div>
+          </React.Fragment>
+        </Scoped>
+      </div>,
+      el
+    );
+
+    expect(el.querySelector("#greeting").dataset.kackle).not.toBe(undefined);
+    expect(el.querySelector("#farewell").dataset.kackle).not.toBe(undefined);
+    expect(el.querySelector("#color").dataset.kackle).not.toBe(undefined);
+    expect(el.querySelector("#color2").dataset.kackle).not.toBe(undefined);
+
+    ReactDOM.unmountComponentAtNode(el);
+
+  });
+
 });


### PR DESCRIPTION
See #14: Kremling will add attribute to React Fragment children