### PR TITLE
adds handling of null children for Scoped

### DIFF
--- a/src/scoped.component.js
+++ b/src/scoped.component.js
@@ -31,11 +31,13 @@ export class Scoped extends React.Component {
 
   addKremlingAttributeToChildren = (children) => {
     return React.Children.map(children, child => {
-      if (child.type === React.Fragment && React.Fragment) {
-        const fragmentChildren = this.addKremlingAttributeToChildren(child.props.children);
-        return React.cloneElement(child, {}, fragmentChildren);
-      } else if (React.isValidElement(child)) {
-        return React.cloneElement(child, {[this.state.kremlingAttrName]: this.state.kremlingAttrValue});
+      if (React.isValidElement(child)) {
+        if (child.type === React.Fragment && React.Fragment) {
+          const fragmentChildren = this.addKremlingAttributeToChildren(child.props.children);
+          return React.cloneElement(child, {}, fragmentChildren);
+        } else {
+          return React.cloneElement(child, {[this.state.kremlingAttrName]: this.state.kremlingAttrValue});
+        }
       } else {
         return child;
       }

--- a/src/scoped.component.test.js
+++ b/src/scoped.component.test.js
@@ -456,4 +456,28 @@ describe("<Scoped />", function() {
 
   });
 
+  it("returns null if child is null", function() {
+    const css = `
+      & .someRule {
+        background-color: red;
+      }
+    `;
+
+    const el = document.createElement("div");
+
+    ReactDOM.render(
+      <div>
+        <Scoped css={css} namespace="kackle">
+          null
+        </Scoped>
+      </div>,
+      el
+    );
+    console.log(el.innerHTML);
+    expect(el.innerHTML).toBe('<div>null</div>');
+
+    ReactDOM.unmountComponentAtNode(el);
+
+  })
+
 });

--- a/src/scoped.component.test.js
+++ b/src/scoped.component.test.js
@@ -473,7 +473,6 @@ describe("<Scoped />", function() {
       </div>,
       el
     );
-    console.log(el.innerHTML);
     expect(el.innerHTML).toBe('<div>null</div>');
 
     ReactDOM.unmountComponentAtNode(el);


### PR DESCRIPTION
## bug
- if null is a child, Kremling will return null rather than adding the Kremling attribute