### PR TITLE
allow empty styles for postcss

### DIFF
--- a/src/scoped.component.js
+++ b/src/scoped.component.js
@@ -19,7 +19,7 @@ export class Scoped extends React.Component {
     this.state = {};
     if (!props.css && !props.postcss) throw Error(`Kremling's <Scoped /> component requires either the 'css' or 'postcss' props.`);
     if (props.css && props.postcss) throw Error(`Kremling's <Scoped /> component requires either the 'css' or 'postcss' props. Cannot use both.`);
-    if (props.postcss && !(typeof props.postcss.styles === 'string' && props.postcss.id)) throw Error(`Kremlings's <Scoped /> component 'postcss' prop requires an object containing 'styles' and 'id' properties. Try using the kremling-loader.`);
+    if (props.postcss && !(typeof props.postcss.styles === 'string' && props.postcss.id)) throw Error(`Kremling's <Scoped /> component 'postcss' prop requires an object containing 'styles' and 'id' properties. Try using the kremling-loader.`);
 
     this.state = this.newCssState(props)
   }

--- a/src/use-css.hook.js
+++ b/src/use-css.hook.js
@@ -3,7 +3,7 @@ import {Scoped} from './scoped.component.js'
 import {styleTags, incrementCounter, transformCss} from './style-element-utils.js'
 
 export function useCss(css, overrideNamespace) {
-  const isPostCss = Boolean(css && css.id && css.styles)
+  const isPostCss = Boolean(css && css.id)
   const namespace = overrideNamespace || (isPostCss && css.namespace) || Scoped.defaultNamespace
   const [styleElement, setStyleElement] = useState(() => getStyleElement(null, isPostCss, css, namespace))
   useStyleElement()

--- a/src/use-css.hook.js
+++ b/src/use-css.hook.js
@@ -3,7 +3,10 @@ import {Scoped} from './scoped.component.js'
 import {styleTags, incrementCounter, transformCss} from './style-element-utils.js'
 
 export function useCss(css, overrideNamespace) {
-  const isPostCss = Boolean(css && css.id)
+  const isPostCss = typeof css === 'object'
+  if (isPostCss && !(css.id && typeof css.styles === 'string')) {
+    throw Error(`Kremling's "useCss" hook requires "id" and "styles" properties when using the kremling-loader`)
+  }
   const namespace = overrideNamespace || (isPostCss && css.namespace) || Scoped.defaultNamespace
   const [styleElement, setStyleElement] = useState(() => getStyleElement(null, isPostCss, css, namespace))
   useStyleElement()

--- a/src/use-css.test.js
+++ b/src/use-css.test.js
@@ -136,6 +136,22 @@ describe('useCss()', () => {
       ReactDOM.unmountComponentAtNode(container)
     })
   })
+
+  it(`postcss should accept empty style strings`, () => {
+    const postcss = {
+      id: '15',
+      styles: ``,
+      namespace: 'donkey-kong',
+    }
+
+    act(() => {
+      ReactDOM.render(<ScopedDiv css={postcss} />, container)
+    })
+    expect(container.innerHTML).toEqual('<div donkey-kong="15"></div>')
+    act(() => {
+      ReactDOM.unmountComponentAtNode(container)
+    })
+  })
 })
 
 function ScopedDiv(props) {


### PR DESCRIPTION
checking for `css.id` is enough to know whether it's postcss or not (`scoped.component.js` already does this on line 95)