### PR TITLE
WIP - added k tag

### DIFF
--- a/src/k.js
+++ b/src/k.js
@@ -1,0 +1,5 @@
+export function k(strings, ...args) {
+  return strings.map((item, i) => {
+    return `${item}${args[i] || ''}`;
+  }).join('');
+}

--- a/src/k.test.js
+++ b/src/k.test.js
@@ -1,0 +1,15 @@
+import { k } from './k';
+
+describe('k', () => {
+  test(`should literally do nothing`, () => {
+    const styles = `.test { background-color: red; };`;
+    expect(k`${styles}`).toEqual(styles);
+  });
+
+  test(`should handle nested placeholders`, () => {
+    const styles = `.test {
+      background-color: ${k ? 'red' : `${'blue' || 'green'}`}
+    }`;
+    expect(k`${styles}`).toEqual(styles);
+  });
+});

--- a/src/kremling.d.ts
+++ b/src/kremling.d.ts
@@ -8,6 +8,7 @@ declare namespace Kremling {
   function m(className: string, condition: any): KremlingString & string;
   function toggle(truthyClass: string, falsyClass: string, condition: any): KremlingString & string;
   function t(truthyClass: string, falsyClass: string, condition: any): KremlingString & string;
+  function k(strings: Array<string>, ...args: Array<string>): object;
 
   interface KremlingString extends String {
     always(className: string): KremlingString & string,
@@ -22,5 +23,5 @@ declare namespace Kremling {
   type Scope = {
     'data-kremling': string,
   }
-  asdfdsa
+
 }

--- a/src/kremling.js
+++ b/src/kremling.js
@@ -1,3 +1,4 @@
 export {always, a, maybe, m, toggle, t, css, c} from './classname-helpers.js';
 export {Scoped} from './scoped.component.js';
 export {useCss} from './use-css.hook.js';
+export {k} from './k.js';


### PR DESCRIPTION
### new proposal (concerning #32 )

what if we just export a simple `k` template literal tag that literally does nothing, except it now allows us to target the tagged template literal expression so we can get syntax highlighting

eg:

```javascript
import { k } from 'kremling';

const styles = k`
  & .test {
    background-color: red;
  }
`;
```

this is extremely easy to set up in intellij/webstorm/etc - just add a new language injection for `scss` (css doesn't allow ampersands), and paste in this line for the pattern:

```
+ taggedString("k")
```

I did some research on building an intellij plugin, and it seems pretty straight forward.

vscode should be pretty easy too - just need to fork `vscode-styled-components` and make it work with `k` instead of `styled.*`

thoughts?