### PR TITLE
remove postcss prop

### DIFF
--- a/src/scoped.component.js
+++ b/src/scoped.component.js
@@ -18,6 +18,10 @@ export class Scoped extends React.Component {
     super(props);
     this.state = {};
     if (!props.css) throw Error(`Kremling's <Scoped /> component requires the 'css' prop.`);
+    if (typeof props.css === 'object' && (
+      typeof props.css.id !== 'string' ||
+      typeof props.css.styles !== 'string')
+    ) throw Error(`Kremling's <Scoped /> component requires either a string or an object with "id" and "styles" properties.`);
     this.state = this.newCssState(props)
   }
 

--- a/src/scoped.component.js
+++ b/src/scoped.component.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import PropTypes from 'prop-types';
+import { string, object, oneOfType } from 'prop-types';
 import {styleTags, incrementCounter, transformCss} from './style-element-utils.js'
 
 const reactSupportsReturningArrays = !!ReactDOM.createPortal;
 
 export class Scoped extends React.Component {
   static propTypes = {
-    css: PropTypes.string,
-    postcss: PropTypes.object,
-    namespace: PropTypes.string,
+    css: oneOfType([string, object]),
+    postcss: object,
+    namespace: string,
   }
 
   static defaultNamespace = 'kremling'
@@ -17,10 +17,7 @@ export class Scoped extends React.Component {
   constructor(props) {
     super(props);
     this.state = {};
-    if (!props.css && !props.postcss) throw Error(`Kremling's <Scoped /> component requires either the 'css' or 'postcss' props.`);
-    if (props.css && props.postcss) throw Error(`Kremling's <Scoped /> component requires either the 'css' or 'postcss' props. Cannot use both.`);
-    if (props.postcss && !(typeof props.postcss.styles === 'string' && props.postcss.id)) throw Error(`Kremling's <Scoped /> component 'postcss' prop requires an object containing 'styles' and 'id' properties. Try using the kremling-loader.`);
-
+    if (!props.css) throw Error(`Kremling's <Scoped /> component requires the 'css' prop.`);
     this.state = this.newCssState(props)
   }
 

--- a/src/scoped.postcss.test.js
+++ b/src/scoped.postcss.test.js
@@ -20,7 +20,7 @@ describe('<Scoped postcss />', function() {
     }
     const el = document.createElement('div');
     ReactDOM.render(
-      <Scoped postcss={css}>
+      <Scoped css={css}>
         <div className="crazy">Okay</div>
       </Scoped>,
       el
@@ -38,7 +38,7 @@ describe('<Scoped postcss />', function() {
     const el = document.createElement('div');
     ReactDOM.render(
       <div>
-        <Scoped postcss={css}>
+        <Scoped css={css}>
           <div>Hello</div>
         </Scoped>
       </div>,
@@ -51,7 +51,7 @@ describe('<Scoped postcss />', function() {
 
   it('when webpack updates its styles, component should update the kremling attribute and inner css', function() {
     let css = { id: '1', styles: `[kremling-1] .someRule, [kremling-1].someRule {background-color: red;}` };
-    const component = (style) => <div><Scoped postcss={style}><div>Hello</div></Scoped></div>;
+    const component = (style) => <div><Scoped css={style}><div>Hello</div></Scoped></div>;
 
     const el = document.createElement('div');
     ReactDOM.render(component(css), el);
@@ -65,7 +65,7 @@ describe('<Scoped postcss />', function() {
 
   it('when the user updates its id, component should update <style> kremling attribute', function() {
     let css = { id: '1', styles: `[kremling-1] .someRule, [kremling-1].someRule {background-color: red;}` };
-    const component = (style) => <div><Scoped postcss={style}><div>Hello</div></Scoped></div>;
+    const component = (style) => <div><Scoped css={style}><div>Hello</div></Scoped></div>;
 
     const el = document.createElement('div');
     ReactDOM.render(component(css), el);
@@ -88,7 +88,7 @@ describe('<Scoped postcss />', function() {
 
     ReactDOM.render(
       <div>
-        <Scoped postcss={css}>
+        <Scoped css={css}>
           <div>Hello</div>
         </Scoped>
       </div>,
@@ -99,7 +99,7 @@ describe('<Scoped postcss />', function() {
 
     ReactDOM.render(
       <div>
-        <Scoped postcss={css}>
+        <Scoped css={css}>
           <div>Hello</div>
         </Scoped>
       </div>,
@@ -115,7 +115,7 @@ describe('<Scoped postcss />', function() {
 
   it(`shouldn't throw errors when empty postcss.styles is passed in`, () => {
     const css = { id: '1', styles: '' };
-    const component = (style) => <div><Scoped postcss={style}><div>Hello</div></Scoped></div>;
+    const component = (style) => <div><Scoped css={style}><div>Hello</div></Scoped></div>;
     const el = document.createElement('div');
     ReactDOM.render(component(css), el);
     expect(document.head.querySelector('style').innerHTML).toEqual('');

--- a/src/scoped.postcss.test.js
+++ b/src/scoped.postcss.test.js
@@ -1,7 +1,6 @@
 import React from "react";
 import ReactDOM from "react-dom";
 import {Scoped} from "./scoped.component.js";
-import {styleTags} from './style-element-utils.js'
 import {resetState} from './style-element-utils.js'
 
 describe('<Scoped postcss />', function() {
@@ -15,7 +14,7 @@ describe('<Scoped postcss />', function() {
   it("should generate and cleanup style tags", function() {
     expect(document.head.querySelectorAll(`style[type="text/css"]`).length).toBe(0);
     const css = {
-      id: 1,
+      id: '1',
       styles: `[kremling="1"] .someRule, [kremling="1"].someRule {background-color: red;}`,
     }
     const el = document.createElement('div');
@@ -32,7 +31,7 @@ describe('<Scoped postcss />', function() {
 
   it('should create a <style> tag with postcss styles', function() {
     const css = {
-      id: 1,
+      id: '1',
       styles: `[kremling="1"] .someRule, [kremling="1"].someRule {background-color: red;}`,
     }
     const el = document.createElement('div');


### PR DESCRIPTION
- remove `postcss` prop, and allow `css` prop to handle objects as well
- this is a breaking change, but since it only affects `kremling-loader` users, I think we can do a minor version update: `v1.3.0`