### PR TITLE
handle variable number of arguments for "always"

### DIFF
--- a/src/kremling.d.ts
+++ b/src/kremling.d.ts
@@ -4,8 +4,8 @@ export = Kremling;
 
 declare namespace Kremling {
   function useCss(css: string | object): Scope;
-  function always(className: string): KremlingString & string;
-  function a(className: string): KremlingString & string;
+  function always(...className: string[]): KremlingString & string;
+  function a(...className: string[]): KremlingString & string;
   function maybe(className: string, condition: any): KremlingString & string;
   function m(className: string, condition: any): KremlingString & string;
   function toggle(truthyClass: string, falsyClass: string, condition: any): KremlingString & string;
@@ -13,8 +13,8 @@ declare namespace Kremling {
   function k(strings: TemplateStringsArray, ...args: Array<string>): object | string;
 
   interface KremlingString extends String {
-    always(className: string): KremlingString & string,
-    a(className: string): KremlingString & string,
+    always(...className: string[]): KremlingString & string,
+    a(...className: string[]): KremlingString & string,
     maybe(className: string, condition: any): KremlingString & string,
     m(className: string, condition: any): KremlingString & string,
     toggle(truthyClass: string, falsyClass: string, condition: any): KremlingString & string,


### PR DESCRIPTION
`always` accepts a variable number of strings - just fixing the type declarations